### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=ConfigDB
+version=1.0
+author=Hector Oliveros
+maintainer=Hector Oliveros
+sentence=A fast way to store configurations data in the fake EEPROM memory (NodeMCU / esp8266 12e).
+paragraph=Saving data structures in the EEPROM can be complicated. This library was created with the purpose of facilitating the saving of configurations in the EEPROM memory.
+category=Other
+url=https://github.com/Eitol/ConfigDB
+architectures=esp8266
+includes=configdb.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the Arduino Library Manager index.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata